### PR TITLE
Wrap in stdlib ensure_packages...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,9 +105,7 @@ class xtrabackup ($dbuser,             # Database username
       }
   }
 
-  package { "percona-xtrabackup":
-    ensure => installed,
-  }
+  ensure_packages(['percona-xtrabackup'])
 
   file { "/usr/local/bin/mysql-backup":
     owner   => "root",


### PR DESCRIPTION
 So we don't have conflicts with other modules, like mariadb which installs percona-xtrabackup for replication
