### PR TITLE
Add option to enable silent cron runs.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,9 @@
 #   Whether to install Xtrabackup 2.0; if set to false installs the latest (2.1)
 #   instead.
 #   (Optional, disabled by default)
+# [*statusfile*]
+#   File to touch in case the backup was successfull. Can be used for to monitor
+#   the backup status using check_file_age.
 #
 # === Examples
 #
@@ -105,6 +108,7 @@ class xtrabackup ($dbuser,              # Database username
                   $cronjob    = true,   # Install a cron job
                   $silentcron = false,  # Send emails always
                   $install_20 = false,  # Install 2.0 instead of latest
+                  $statusfile = undef,  # statusfile to touch if cronjob was successfull.
                  ) {
 
   if ($addrepo) {

--- a/templates/backupscript.sh.erb
+++ b/templates/backupscript.sh.erb
@@ -53,6 +53,10 @@ if [ "${SILENT}" != "silent" -o $ret -gt 0 ]; then
     cat ${TMP}
 fi
 
+<% if @statusfile -%>
+if [ $ret -eq 0 ]; then touch <%= @statusfile -%>; fi
+<% end -%>
+
 <% if @keepdays -%>
 keepdays
 <% end -%>

--- a/templates/backupscript.sh.erb
+++ b/templates/backupscript.sh.erb
@@ -4,25 +4,60 @@
 # (C) 2013 Bashton Ltd
 
 DATE=$( date +%Y-%m-%d )
+TMP=$(mktemp)
+SILENT="$1"
 
-/usr/bin/innobackupex \
-  --stream=xbstream \
-  --user=<%= @dbuser %> \
-  --password=<%= @dbpass %> \
-  --parallel=<%= @parallel %> \
-<%= "  --slave-info \\\n" if @slaveinfo -%>
-<%= "  --safe-slave-backup \\\n" if @safeslave -%>
-<%= "  " + @workdir + " \\\n" -%>
-<%= "  | gzip -c9 \\\n" if @gzip -%>
-<%= "  | ssh " + @sshdest if @sshdest -%>
-<%= " -i " + @sshkey + " \\\n" if @sshkey -%>
-<%= "  cat - \\\n" if @sshdest -%>
-  > <%= @outputdir -%>/mysql-backup-${DATE}.xbstream<%= ".gz" if @gzip %>
+function cleanup() {
+    rm -f ${TMP}
+}
+
+function backup() {
+    /usr/bin/innobackupex \
+      --stream=xbstream \
+      --user=<%= @dbuser %> \
+      --password=<%= @dbpass %> \
+      --parallel=<%= @parallel %> \
+    <%= "  --slave-info \\\n" if @slaveinfo -%>
+    <%= "  --safe-slave-backup \\\n" if @safeslave -%>
+    <%= "  " + @workdir + " \\\n" -%>
+    <%= "  | gzip -c9 \\\n" if @gzip -%>
+    <%= "  | ssh " + @sshdest if @sshdest -%>
+    <%= " -i " + @sshkey + " \\\n" if @sshkey -%>
+    <%= "  cat - \\\n" if @sshdest -%>
+        > <%= @outputdir -%>/mysql-backup-${DATE}.xbstream<%= ".gz" if @gzip %>
+
+    for i in ${PIPESTATUS[@]}; do
+        if [ $i -gt 0 ]; then
+            return $i
+        fi
+    done
+}
 
 <% if @keepdays -%>
-# Clean up backups older than <%= @keepdays %>
-<%= "ssh " + @sshdest if @sshdest -%>
-<%= " -i " + @sshkey + " \\\n  " if @sshkey -%>
-find <%= @outputdir %> -maxdepth 1 -name 'mysql-backup-*.xbstream*' \
-  -type f -mtime +<%= @keepdays %> -delete
+function keepdays() {
+    # Clean up backups older than <%= @keepdays %>
+    <%= "ssh " + @sshdest if @sshdest -%>
+    <%= " -i " + @sshkey + " \\\n  " if @sshkey -%>
+    find <%= @outputdir %> -maxdepth 1 -name 'mysql-backup-*.xbstream*' \
+      -type f -mtime +<%= @keepdays %> -delete
+}
 <% end -%>
+
+
+trap cleanup EXIT
+
+backup 2>${TMP}
+ret=$?
+
+if [ "${SILENT}" != "silent" -o $ret -gt 0 ]; then
+    cat ${TMP}
+fi
+
+<% if @keepdays -%>
+keepdays
+<% end -%>
+
+trap - EXIT
+cleanup
+
+exit $ret


### PR DESCRIPTION
If activated, cron will send emails on errors only.

The only downside is that during a manual run, the output of the script is pretty much delayed. It should be possible to check if the script is running under cron and if not, keep the direct output instead of redirecting it into a file. But for now this works for me, feel free to merge or ignore :-)
